### PR TITLE
Apply emergency hotfix to Galactic/Round

### DIFF
--- a/themes/EMERALD-Galactic.json
+++ b/themes/EMERALD-Galactic.json
@@ -1,6 +1,6 @@
 {
   "repo_url": "https://github.com/EMERALD0874/Steam-Deck-Themes",
   "repo_subpath": "Galactic",
-  "repo_commit": "34bb59e",
+  "repo_commit": "b4f7284",
   "preview_image_path": "images/EMERALD/Galactic.jpg"
 }

--- a/themes/EMERALD-Round.json
+++ b/themes/EMERALD-Round.json
@@ -1,6 +1,6 @@
 {
   "repo_url": "https://github.com/EMERALD0874/Steam-Deck-Themes",
   "repo_subpath": "Round",
-  "repo_commit": "c1fc0da",
+  "repo_commit": "b4f7284",
   "preview_image_path": "images/EMERALD/Round.jpg"
 }


### PR DESCRIPTION
# Galactic, Round

Patches a bug where both themes will break the theme store. This is an emergency hotfix, so please review ASAP.

### Checklist

The themes have already been added to the store and only emergency bug fixes have been made.