### PR TITLE
Bump colored toggles to v1.3

### DIFF
--- a/themes/SuchMeme-ColoredToggles.json
+++ b/themes/SuchMeme-ColoredToggles.json
@@ -1,6 +1,6 @@
 {
     "repo_url": "https://github.com/suchmememanyskill/Steam-Deck-Themes",
     "repo_subpath": "Colored_Toggles",
-    "repo_commit": "d9f160",
+    "repo_commit": "ed617ac",
     "preview_image_path": "images/SuchMeme/ColoredToggles.jpg"
 }


### PR DESCRIPTION
# Colored Toggles

https://github.com/suchmememanyskill/Steam-Deck-Themes/commit/ed617ac14e31327adb8d33bf386c78b218c42cb2

Fixes the progress bar being empty underneath games in the home menu

### Checklist

Failure to complete this checklist or deleting boxes from the checklist will result in the closing of your pull request. Please write any comments regarding this checklist at the bottom of your pull request.

Check every box.
- [X] I am the original author of this theme or have permission from the original author to make this pull request.
- [X] All copyright of this theme's contents belong to the listed author or is cited in the repository linked above.
- [X] This theme's target has been marked appropriately and only styles said target.
- [X] This theme works properly on the latest versions of SteamOS for Steam Deck, [decky-loader](https://github.com/SteamDeckHomebrew/decky-loader) and [SDH-CssLoader](https://github.com/suchmememanyskill/SDH-CssLoader).
- [X] This theme only uses `*` or `!important` if absolutely necessary.
- [X] This theme is under 10MB in size and uses the least disk space possible.
- [X] This theme's preview image does not include text unless it is necessary to describe changes that can be made.
- [X] This theme is safe for work and does not contain any sexual, drug-related, or profane content.

Check one box.
- [X] I am not bundling a part of another theme with this theme to encourage mixing and matching themes.
- [ ] Themes included with this theme are toggleable using a patch.

Check one box.
- [ ] This is a keyboard theme applied to the default keyboard.
- [ ] This is a system-wide theme applied to the default keyboard. The keyboard is toggleable using a patch.
- [X] This theme does not target the keyboard.
