### PR TITLE
Update EMERALD themes

### DIFF
--- a/themes/EMERALD-Galactic.json
+++ b/themes/EMERALD-Galactic.json
@@ -1,6 +1,6 @@
 {
   "repo_url": "https://github.com/EMERALD0874/Steam-Deck-Themes",
   "repo_subpath": "Galactic",
-  "repo_commit": "b5f2f31",
+  "repo_commit": "174c9e5",
   "preview_image_path": "images/EMERALD/Galactic.jpg"
 }

--- a/themes/EMERALD-Obsidian.json
+++ b/themes/EMERALD-Obsidian.json
@@ -1,6 +1,6 @@
 {
   "repo_url": "https://github.com/EMERALD0874/Steam-Deck-Themes",
   "repo_subpath": "Obsidian",
-  "repo_commit": "c1fc0da",
+  "repo_commit": "174c9e5",
   "preview_image_path": "images/EMERALD/Obsidian.jpg"
 }

--- a/themes/EMERALD-Round.json
+++ b/themes/EMERALD-Round.json
@@ -1,6 +1,6 @@
 {
   "repo_url": "https://github.com/EMERALD0874/Steam-Deck-Themes",
   "repo_subpath": "Round",
-  "repo_commit": "b5f2f31",
+  "repo_commit": "174c9e5",
   "preview_image_path": "images/EMERALD/Round.jpg"
 }


### PR DESCRIPTION
# Galactic, Obsidian, Round

- Round
    - Default has been changed to 10px (also applies to Galactic)
    - Added patch for changing intensity
- Obsidian
    - Added patch for changing color to dark gray, gray, or any color of the rainbow

https://github.com/EMERALD0874/Steam-Deck-Themes

### Checklist

Failure to complete this checklist or deleting boxes from the checklist will result in the closing of your pull request. Please write any comments regarding this checklist at the bottom of your pull request.

Check every box.
- [x] I am the original author of this theme or have permission from the original author to make this pull request.
- [x] All copyright of this theme's contents belong to the listed author or is cited in the repository linked above.
- [x] This theme's target has been marked appropriately and only styles said target.
- [x] This theme works properly on the latest versions of SteamOS for Steam Deck, [decky-loader](https://github.com/SteamDeckHomebrew/decky-loader) and [SDH-CssLoader](https://github.com/suchmememanyskill/SDH-CssLoader).
- [x] This theme only uses `*` or `!important` if absolutely necessary.
- [x] This theme is under 10MB in size and uses the least disk space possible.
- [x] This theme's preview image does not include text unless it is necessary to describe changes that can be made.
- [x] This theme is safe for work and does not contain any sexual, drug-related, or profane content.

Check one box.
- [ ] I am not bundling a part of another theme with this theme to encourage mixing and matching themes.
- [x] Themes included with this theme are toggleable using a patch.

Check one box.
- [ ] This is a keyboard theme applied to the default keyboard.
- [ ] This is a system-wide theme applied to the default keyboard. The keyboard is toggleable using a patch.
- [x] This theme does not target the keyboard.
