### PR TITLE
Add new font, Round fixes

### DIFF
--- a/themes/EMERALD-Fonts.json
+++ b/themes/EMERALD-Fonts.json
@@ -1,6 +1,6 @@
 {
   "repo_url": "https://github.com/EMERALD0874/Steam-Deck-Themes",
   "repo_subpath": "Fonts",
-  "repo_commit": "c1fc0da",
+  "repo_commit": "ad6b2f5",
   "preview_image_path": "images/EMERALD/Fonts.jpg"
 }

--- a/themes/EMERALD-Galactic.json
+++ b/themes/EMERALD-Galactic.json
@@ -1,6 +1,6 @@
 {
   "repo_url": "https://github.com/EMERALD0874/Steam-Deck-Themes",
   "repo_subpath": "Galactic",
-  "repo_commit": "174c9e5",
+  "repo_commit": "ad6b2f5",
   "preview_image_path": "images/EMERALD/Galactic.jpg"
 }

--- a/themes/EMERALD-Round.json
+++ b/themes/EMERALD-Round.json
@@ -1,6 +1,6 @@
 {
   "repo_url": "https://github.com/EMERALD0874/Steam-Deck-Themes",
   "repo_subpath": "Round",
-  "repo_commit": "174c9e5",
+  "repo_commit": "ad6b2f5",
   "preview_image_path": "images/EMERALD/Round.jpg"
 }


### PR DESCRIPTION
# Fonts, Round

- Improved Round compatibility with Switch-Like Home.
- Added rounding to news articles.
- Added Bahnschrift as a font choice.

https://github.com/EMERALD0874/Steam-Deck-Themes

### Checklist

No major changes have been made to change the checklist since the initial commits.