### PR TITLE
Add Phantom multiple colors

### DIFF
--- a/themes/EMERALD-Phantom.json
+++ b/themes/EMERALD-Phantom.json
@@ -1,6 +1,6 @@
 {
   "repo_url": "https://github.com/EMERALD0874/Steam-Deck-Themes",
   "repo_subpath": "Phantom",
-  "repo_commit": "2e8dcf4",
+  "repo_commit": "999e4fa",
   "preview_image_path": "images/EMERALD/Phantom.jpg"
 }


### PR DESCRIPTION
# Phantom

Add colors for the various Phantom Thieves to Phantom. Colors have not been added to any areas not previously touched by the theme.

https://github.com/EMERALD0874/Steam-Deck-Themes/tree/main/Phantom

### Checklist

This is a theme update.