### PR TITLE
Gawr Gura - Theme the Decky Store so that its readable.

### DIFF
--- a/themes/joamjoamjoam-GawrGura.json
+++ b/themes/joamjoamjoam-GawrGura.json
@@ -1,6 +1,6 @@
 {
     "repo_url": "https://github.com/joamjoamjoam/SteamDeckThemes",
     "repo_subpath": "Gawr Gura Theme/Gawr Gura",
-    "repo_commit": "4954dab",
+    "repo_commit": "5813e53",
     "preview_image_path": "images/joamjoamjoam/GawrGura.jpg"
 }

--- a/themes/joamjoamjoam-GawrGura.json
+++ b/themes/joamjoamjoam-GawrGura.json
@@ -1,6 +1,6 @@
 {
     "repo_url": "https://github.com/joamjoamjoam/SteamDeckThemes",
     "repo_subpath": "Gawr Gura Theme/Gawr Gura",
-    "repo_commit": "5813e53",
+    "repo_commit": "3c1ea68",
     "preview_image_path": "images/joamjoamjoam/GawrGura.jpg"
 }


### PR DESCRIPTION
Gawr Gura

[Gawr Gura Repo](https://github.com/joamjoamjoam/SteamDeckThemes/tree/main/Gawr%20Gura%20Theme)

Changes:
- Add a theme to the Decky Store So that you can actually read it. (works on pre13 and up)