### PR TITLE
Update Minimal Lock Screen to use color-pickers

### DIFF
--- a/themes/joamjoamjoam-MinimalLockScreen.json
+++ b/themes/joamjoamjoam-MinimalLockScreen.json
@@ -1,6 +1,6 @@
 {
     "repo_url": "https://github.com/joamjoamjoam/SteamDeckThemes",
     "repo_subpath": "Minimal Lock Screen Theme/Minimal Lock Screen",
-    "repo_commit": "e97801b",
+    "repo_commit": "a4439f2",
     "preview_image_path": "images/joamjoamjoam/minimalLockScreen.jpg"
 }

--- a/themes/joamjoamjoam-MinimalLockScreen.json
+++ b/themes/joamjoamjoam-MinimalLockScreen.json
@@ -1,6 +1,6 @@
 {
     "repo_url": "https://github.com/joamjoamjoam/SteamDeckThemes",
     "repo_subpath": "Minimal Lock Screen Theme/Minimal Lock Screen",
-    "repo_commit": "e9b04b9",
+    "repo_commit": "e97801b",
     "preview_image_path": "images/joamjoamjoam/minimalLockScreen.jpg"
 }


### PR DESCRIPTION
# Minimal Lock Screen

(Minimal Lock Screen Repo)[https://github.com/joamjoamjoam/SteamDeckThemes/tree/main/Minimal%20Lock%20Screen%20Theme]

Changes:
- Update Manifest Version to v3
- Replace Color Selector dropdowns with color-picker components


