### PR TITLE
Cache themes through cloudflare

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,7 +51,7 @@ class B2Bucket():
     def getFileUrl(self, fileName : str) -> str:
         for x in self.files:
             if x.key == fileName:
-                return f"{self.resource.ENDPOINT}/{x.bucket_name}/{x.key}"
+                return f"https://cdn.beebl.es/file/{x.bucket_name}/{x.key}"
 
         return None
     


### PR DESCRIPTION
Not a theme PR, we keep blowing through the daily limits on Class B transactions, so I have set up cloudflare caching on my cdn.beebl.es domain to point to our backblaze bucket;