### PR TITLE
Actually bump version on the 2 themes I updated

### DIFF
--- a/themes/Beebles-ColoredCompatIcons.json
+++ b/themes/Beebles-ColoredCompatIcons.json
@@ -1,6 +1,6 @@
 {
     "repo_url": "https://github.com/beebls/Steam-Deck-Themes",
     "repo_subpath": "Colored Compat Icons",
-    "repo_commit": "6fa2349",
+    "repo_commit": "de194ca",
     "preview_image_path": "images/Beebles/CustomCompatIcons.jpg"
 }

--- a/themes/Beebles-ColorfulRecent.json
+++ b/themes/Beebles-ColorfulRecent.json
@@ -1,6 +1,6 @@
 {
   "repo_url": "https://github.com/beebls/Steam-Deck-Themes",
   "repo_subpath": "Colorful Recent",
-  "repo_commit": "de194ca",
+  "repo_commit": "668bef0",
   "preview_image_path": "images/Beebles/ColorfulRecent.jpg"
 }

--- a/themes/Beebles-ColorfulRecent.json
+++ b/themes/Beebles-ColorfulRecent.json
@@ -1,6 +1,6 @@
 {
   "repo_url": "https://github.com/beebls/Steam-Deck-Themes",
   "repo_subpath": "Colorful Recent",
-  "repo_commit": "6fa2349",
+  "repo_commit": "de194ca",
   "preview_image_path": "images/Beebles/ColorfulRecent.jpg"
 }


### PR DESCRIPTION
# Colorful Recent & Colored Compat Icons

This changes 0 CSS, just bumps version numbers

### Checklist

Failure to complete this checklist or deleting boxes from the checklist will result in the closing of your pull request unless this is a theme update. Please write any comments regarding this checklist at the bottom of your pull request.

Check every box.
- [x] I am the original author of this theme or have permission from the original author to make this pull request.
- [x] All copyright of this theme's contents belong to the listed author or is cited in the repository linked above.
- [x] This theme's target has been marked appropriately and only styles said target.
- [x] This theme works properly on the latest versions of SteamOS for Steam Deck, [decky-loader](https://github.com/SteamDeckHomebrew/decky-loader) and [SDH-CssLoader](https://github.com/suchmememanyskill/SDH-CssLoader).
- [x] This theme only uses `*` or `!important` if absolutely necessary.
- [x] This theme is under 4MB in size and uses the least disk space possible.
- [x] This theme's preview image does not include text unless it is necessary to describe changes that can be made.
- [x] This theme is safe for work and does not contain any sexual, drug-related, or profane content.
- [x] This theme prefixes any CSS variables with a unique identifier.

Check one box.
- [x] I am not bundling a part of another theme with this theme to encourage mixing and matching themes.
- [ ] Themes included with this theme are toggleable using a patch.

Check one box.
- [ ] This is a keyboard theme applied to the default keyboard.
- [ ] This is a system-wide theme applied to the default keyboard. The keyboard is toggleable using a patch.
- [x] This theme does not target the keyboard.
