### PR TITLE
Update RGB keyboard

### DIFF
--- a/themes/Party Wumpus-RGB Keyboard.json
+++ b/themes/Party Wumpus-RGB Keyboard.json
@@ -1,6 +1,6 @@
 {
     "repo_url": "https://github.com/vrman123/PoyomannSteamDeckThemes",
     "repo_subpath": "RGB keyboard",
-    "repo_commit": "8b5bb3f",
+    "repo_commit": "cf26ede",
     "preview_image_path": "images/Party Wumpus/RGB keyboard.jpg"
 }


### PR DESCRIPTION
# RGB keyboard (update)

https://github.com/PartyWumpus/PoyomannSteamDeckThemes
just small changes, all done by milroneth:
- Renamed `--rgbkeyboard-keyboard-colour` to `--rgbkeyboard-keyboard-color` for
  consistency
- Fixed multiple undeclared variable reads by adding missing `rgbkeyboard-` pfx
- Fixed `emoji`, `pointer` and `deadkey` background and inactive colors
- Added missing semicolons to fix current syntax error and avoid future ones

### Checklist

Failure to complete this checklist or deleting boxes from the checklist will result in the closing of your pull request unless this is a theme update. Please write any comments regarding this checklist at the bottom of your pull request.

Check every box.
- [x] I am the original author of this theme or have permission from the original author to make this pull request.
- [x] All copyright of this theme's contents belong to the listed author or is cited in the repository linked above.
- [x] This theme's target has been marked appropriately and only styles said target.
- [x] This theme works properly on the latest versions of SteamOS for Steam Deck, [decky-loader](https://github.com/SteamDeckHomebrew/decky-loader) and [SDH-CssLoader](https://github.com/suchmememanyskill/SDH-CssLoader).
- [x] This theme only uses `*` or `!important` if absolutely necessary.
- [x] This theme is under 4MB in size and uses the least disk space possible.
- [x] This theme's preview image does not include text unless it is necessary to describe changes that can be made.
- [x] This theme is safe for work and does not contain any sexual, drug-related, or profane content.
- [x] This theme prefixes any CSS variables with a unique identifier.

Check one box.
- [x] I am not bundling a part of another theme with this theme to encourage mixing and matching themes.
- [ ] Themes included with this theme are toggleable using a patch.

Check one box.
- [x] This is a keyboard theme applied to the default keyboard.
- [ ] This is a system-wide theme applied to the default keyboard. The keyboard is toggleable using a patch.
- [ ] This theme does not target the keyboard.
