### PR TITLE
Update Gawr Gura to v1.5

### DIFF
--- a/themes/joamjoamjoam-GawrGura.json
+++ b/themes/joamjoamjoam-GawrGura.json
@@ -1,6 +1,6 @@
 {
     "repo_url": "https://github.com/joamjoamjoam/SteamDeckThemes",
     "repo_subpath": "Gawr Gura Theme/Gawr Gura",
-    "repo_commit": "980ea8b",
+    "repo_commit": "ea60844",
     "preview_image_path": "images/joamjoamjoam/GawrGura.jpg"
 }

--- a/themes/joamjoamjoam-GawrGura.json
+++ b/themes/joamjoamjoam-GawrGura.json
@@ -1,6 +1,6 @@
 {
     "repo_url": "https://github.com/joamjoamjoam/SteamDeckThemes",
     "repo_subpath": "Gawr Gura Theme/Gawr Gura",
-    "repo_commit": "3c1ea68",
+    "repo_commit": "980ea8b",
     "preview_image_path": "images/joamjoamjoam/GawrGura.jpg"
 }


### PR DESCRIPTION
# Gawr Gura v 1.5

[Gawr Gura Repo](https://github.com/joamjoamjoam/SteamDeckThemes/tree/main/Gawr%20Gura%20Theme)

Changes:
- Bump to v 1.5
- Use dependencies for shared themes
- Decouple Minimal Lock Screen and use as a dependency
- Fix lockscreen issues with latest stable steam client
